### PR TITLE
Declared compatibility with Grav 2

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -14,6 +14,11 @@ license: MIT
 dependencies:
   - shortcode-core
 
+compatibility:
+  grav:
+    - '1.7'
+    - '2.0'
+
 form:
   validation: strict
   fields:


### PR DESCRIPTION
Declared compatibility with Grav 2 (after testing by me) [as suggested in the migration docs](https://learn.getgrav.org/20/plugins/plugin-compatibility#the-compatibility-property).